### PR TITLE
kode update untuk bisa dibuild di Pi

### DIFF
--- a/Main.qml
+++ b/Main.qml
@@ -10,8 +10,6 @@ Window {
     visible: true
     title: qsTr("Hello World")
 
-    visibility: "FullScreen"
-
     property string latestButton: "Setup"
     property string sourceFileName: "IntensitySlider.qml"
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -37,7 +37,6 @@ int main(int argc, char *argv[])
 
     QTextStream in(fptr);
     std::string content = in.readAll().toStdString();
-    fclose(fptr);
 
     fkyaml::node node = fkyaml::node::deserialize(content);
 


### PR DESCRIPTION
Walaupun skrg masih ada masalah yang ongoing penyelesaiannya.

`
pione@raspberrypi:~/ClonedRepo/gwi/build $ ./appgwi
Authorization required, but no authorization protocol specified

qt.qpa.xcb: could not connect to display :0.0
qt.qpa.plugin: Could not load the Qt platform plugin "xcb" in "" even though it was found.
This application failed to start because no Qt platform plugin could be initialized. Reinstalling the application may fix this problem.

Available platform plugins are: xcb, offscreen, vnc, linuxfb, minimalegl, minimal, eglfs, vkkhrdisplay.

Dibatalkan
pione@raspberrypi:~/ClonedRepo/gwi/build $ sudo ./appgwi
Authorization required, but no authorization protocol specified

qt.qpa.xcb: could not connect to display :0.0
qt.qpa.plugin: Could not load the Qt platform plugin "xcb" in "" even though it was found.
This application failed to start because no Qt platform plugin could be initialized. Reinstalling the application may fix this problem.

Available platform plugins are: xcb, offscreen, vnc, linuxfb, minimalegl, minimal, eglfs, vkkhrdisplay.

Dibatalkan
`