### PR TITLE
added begin() onto constructor

### DIFF
--- a/src/HardwareController.cpp
+++ b/src/HardwareController.cpp
@@ -50,6 +50,8 @@ HardwareController::HardwareController(uint8_t sensorAddr, int adapter, int ledP
      */
     m_sensorTimer->setInterval(2000); 
     connect(m_sensorTimer, &QTimer::timeout, this, &HardwareController::onSensorTimer);
+
+    begin();
 }
 
 /**


### PR DESCRIPTION
`HardwareController::begin()` is the actual initialization method. It needs to be called together with the constructor.